### PR TITLE
fix: rename APIIT to APIT

### DIFF
--- a/components/LoanCalculator.tsx
+++ b/components/LoanCalculator.tsx
@@ -111,7 +111,7 @@ export default function LoanCalculator(): JSX.Element {
 						<span>- {formatCurrency(calculation.applicant1.epf)}</span>
 					</div>
 					<div className="result-row detail-row">
-						<span style={{ paddingLeft: "3rem" }}>Tax (APIIT)</span>
+                                               <span style={{ paddingLeft: "3rem" }}>Tax (APIT)</span>
 						<span>- {formatCurrency(calculation.applicant1.tax)}</span>
 					</div>
 					<div className="result-row subtotal-row">
@@ -135,7 +135,7 @@ export default function LoanCalculator(): JSX.Element {
 								<span>- {formatCurrency(calculation.applicant2.epf)}</span>
 							</div>
 							<div className="result-row detail-row">
-								<span style={{ paddingLeft: "3rem" }}>Tax (APIIT)</span>
+                                                            <span style={{ paddingLeft: "3rem" }}>Tax (APIT)</span>
 								<span>- {formatCurrency(calculation.applicant2.tax)}</span>
 							</div>
 							<div className="result-row subtotal-row">

--- a/components/SalaryCalculator.tsx
+++ b/components/SalaryCalculator.tsx
@@ -74,9 +74,9 @@ export default function SalaryCalculator(): JSX.Element {
 					<span className="amount">- {formatCurrency(salaryDetails.epf)}</span>
 				</div>
 				<div className="result-row">
-					<span className="description" style={{ paddingLeft: "1.5rem" }}>
-						💰 Tax (APIIT)
-					</span>
+                                       <span className="description" style={{ paddingLeft: "1.5rem" }}>
+                                               💰 Tax (APIT)
+                                       </span>
 					<span className="amount">- {formatCurrency(salaryDetails.tax)}</span>
 				</div>
 				<div className="result-row">

--- a/lib/salary.ts
+++ b/lib/salary.ts
@@ -22,7 +22,7 @@ interface TaxBracket {
 }
 
 /**
- * Calculates the monthly APIIT (tax) based on Sri Lankan tax brackets.
+ * Calculates the monthly APIT (tax) based on Sri Lankan tax brackets.
  * @param {number} salary - The gross monthly salary.
  * @returns {number} The calculated monthly tax, rounded to 2 decimal places.
  */


### PR DESCRIPTION
## Summary
- update salary and loan calculators to use APIT label
- fix tax calculation comment to refer to APIT

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894847adb18832c80fb777f919a5f6e