### PR TITLE
Allow full joint contribution range

### DIFF
--- a/components/SalaryEstimator.tsx
+++ b/components/SalaryEstimator.tsx
@@ -86,8 +86,8 @@ export default function SalaryEstimator(): JSX.Element {
 		if (monthlyPayment > 0 && NUMBER_OF_SPLITS > 1) {
 			// Ensure we have at least 2 splits
 			for (let i = 0; i < NUMBER_OF_SPLITS; i++) {
-				// The loop condition and the divisor are now controlled by the same constant
-				const splitRatio = (i / (NUMBER_OF_SPLITS - 1.0)) * 0.5;
+				// The loop condition and the divisor are controlled by the same constant, giving ratios from 0 to 1
+				const splitRatio = i / (NUMBER_OF_SPLITS - 1);
 
 				const installmentA = monthlyPayment * splitRatio;
 				const installmentB = monthlyPayment * (1 - splitRatio);


### PR DESCRIPTION
## Summary
- allow loan installment split ratio to span entire 0–1 range
- keep installment calculations in sync with new ratio

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- manual simulation showing splitRatio values greater than 0.5


------
https://chatgpt.com/codex/tasks/task_e_689485986a8c832cad2b60b6ccae46d0